### PR TITLE
Adapt requirements to Debian Stretch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Sous Debian:
 
 .. code-block:: console
 
-    apt-get install virtualenvwrapper libmysqlclient-dev build-essential libjpeg-dev libfreetype6 libfreetype6-dev zlib1g-dev python-mysqldb redis-server
+    apt-get install virtualenvwrapper libmariadbclient-dev build-essential libjpeg-dev libfreetype6 libfreetype6-dev zlib1g-dev python-mysqldb redis-server
 
 Sous Fedora:
 


### PR DESCRIPTION
libmysqlclient-dev is no longer, in Debian Stretch.