### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ mako_compiled_templates
 data
 *.egg
 dist
-./build
+/build/
 .ropeproject
 tobeignored
 node_modules


### PR DESCRIPTION
(build folder was not actually ignored)

from man gitignore.

> A leading slash matches the beginning of the pathname. For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c"