### PR TITLE
VM de développement vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data
 dist
 /build/
 .ropeproject
+.vagrant/
 tobeignored
 node_modules
 /mail/

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,36 @@ suivantes
     cp development.ini.sample development.ini
 
 
+Base de données avec Vagrant
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pour héberger la base de données dans une machine virtuelle jettable et
+reproductible sans toucher à la machine hôte, une configuration Vagrant est
+disponible. Pour l'utiliser :
+
+.. code-block:: console
+
+    apt install virtualbox vagrant
+
+Et pour lancer cette machine :
+
+.. code-block:: console
+
+    vagrant up
+
+Un serveur MariaDB est alors installé et configuré (port local 13306 de l'hôte
+local, base: autonomie, login: autonomie, password: autonomie).
+
+Des configurations adaptées à vagrant sont commentées dans ``test.ini.sample`` et
+``developement.ini.sample``.
+
+Au besoin, la base peut être remise à zéro avec :
+
+.. code-block:: console
+
+    vagrant provision
+
+
 Tests
 ------
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,34 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+  config.vm.hostname = 'mariadb-server'
+
+  config.vm.network "forwarded_port", guest: 3306, host: 13306
+
+  # Prevent TTY Errors (copied from laravel/homestead: "homestead.rb" file)... By default this is "bash -l".
+  config.ssh.shell = "bash"
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    #!/usr/bin/env bash
+
+    sudo debconf-set-selections <<< 'mariadb-server mariadb-server/root_password password root'
+    sudo debconf-set-selections <<< 'mariadb-server mariadb-server/root_password_again password root'
+    sudo apt-get update
+    sudo apt-get -y install mariadb-server
+    sed -i s/127.0.0.1/0.0.0.0/ /etc/mysql/mariadb.conf.d/50-server.cnf
+    sudo systemctl restart mariadb
+
+    APP_DB_USER=autonomie
+    APP_DB_NAME=autonomie
+    APP_DB_PASS=autonomie
+
+    cat << EOF | sudo su -c mysql -- -u root -proot
+      SET GLOBAL max_connect_errors=10000;
+
+      DROP USER IF EXISTS $APP_DB_USER;
+      DROP DATABASE  IF EXISTS $APP_DB_USER;
+      CREATE DATABASE $APP_DB_NAME;
+      CREATE USER '$APP_DB_USER' IDENTIFIED BY '$APP_DB_PASS';
+      GRANT ALL PRIVILEGES ON $APP_DB_NAME.* TO '$APP_DB_USER';
+      FLUSH PRIVILEGES;
+EOF
+  SHELL
+end

--- a/development.ini.sample
+++ b/development.ini.sample
@@ -41,6 +41,8 @@ pyramid.includes =
 
 #### DATABASE ACCESS CONFIGURATION ####
 sqlalchemy.url = mysql://autonomie:autonomie@localhost/autonomie?charset=utf8
+# Uncomment the following line to use vagrant
+sqlalchemy.url = mysql://autonomie:autonomie@127.0.0.1:13306/autonomie?charset=utf8
 sqlalchemy.echo=False
 #sqlalchemy.encoding=UTF8
 # Those variables should be improved to fit your configuration

--- a/test.ini.sample
+++ b/test.ini.sample
@@ -27,6 +27,17 @@ testdb.drop=echo "DROP DATABASE IF EXISTS testautonomie"|mysql -uroot
 # testdb.adddb=sudo -u postgres psql -c "CREATE DATABASE IF NOT EXISTS testautonomie owner testautonomie;
 # testdb.drop=sudo -u postgres psql -c "DROP DATABASE 'testautonomie'
 
+#### BEGIN VAGRANT CONFIG BLOCK
+# Uncomment the following lines, to use tests if you are using Vagrant
+sqlalchemy.url = mysql://autonomie:autonomie@127.0.0.1:13306/testautonomie?charset=utf8
+sqlalchemy.echo=False
+
+testdb.connect=echo 'quit' | vagrant ssh -c 'sudo mysql -uroot --password=root'
+testdb.adddb=echo "CREATE DATABASE IF NOT EXISTS testautonomie; GRANT ALL PRIVILEGES on testautonomie.* to 'autonomie';FLUSH PRIVILEGES;" | vagrant ssh -c 'sudo mysql -uroot --password=root'
+testdb.adduser=
+testdb.drop=echo "DROP DATABASE IF EXISTS testautonomie"| vagrant ssh -c 'sudo mysql -uroot --password=root'
+#### END VAGRANT CONFIG BLOCK
+
 session.longtimeout=3600
 cache.regions = default_term, second, short_term, long_term
 cache.type = memory


### PR DESCRIPTION
C'est ce que j'utilise (vagrant) de mon côté dans de nombreux projets pour permettre d'avoir un serveur de base de données de référence pour chacun de mes projets de dév sans toucher à ma machine locale. J'ai fait le fichier de conf pour moi, autant le partager.

Le 2e commit permet d'utiliser vagrant pour arriver très vite à un environnement de dév opérationnel (pas d'install/conf de mysql du tout).

Loin de moi l'idée d'imposer ce fonctionnement cela dit, je peux virer le 2e commit au besoin (changement de la conf de déve par défaut).