### PR TITLE
Évite à l'icône fa-folder/fa-folder-open de sortir de sa colone

### DIFF
--- a/autonomie/templates/business/layout.mako
+++ b/autonomie/templates/business/layout.mako
@@ -33,9 +33,9 @@
                 <div class='row'>
                     <div class='col-md-3 text-center'>
                     % if layout.current_business_object.closed:
-                        <i class='fa fa-folder fa-4x'></i>
+                        <i class='fa fa-folder fa-3x'></i>
                     % else:
-                        <i class='fa fa-folder-open fa-4x'></i>
+                        <i class='fa fa-folder-open fa-3x'></i>
                     % endif
                     </div>
                     <div class='col-md-9'>

--- a/autonomie/templates/project/layout.mako
+++ b/autonomie/templates/project/layout.mako
@@ -32,7 +32,7 @@
             <div class='col-md-3 col-xs-12 bordered'>
                 <div class='row'>
                     <div class='col-md-3 text-center'>
-                        <i class='fa fa-folder-open fa-4x'></i>
+                        <i class='fa fa-folder-open fa-3x'></i>
                     </div>
                     <div class='col-md-9'>
                         <div>Projet : ${layout.current_project_object.name}</div>


### PR DESCRIPTION
Trop grande pour sa colonne. Ça n'est pas le cas avec d'autres
icônes (fa-user), qui sont moins larges.

![image](https://user-images.githubusercontent.com/429633/42421381-064af2d4-82d5-11e8-9efe-d00b287601ad.png)
