### PR TITLE
Harmonise l'UI des widgets « Select2 » (et refacto)

### DIFF
--- a/autonomie/forms/__init__.py
+++ b/autonomie/forms/__init__.py
@@ -873,3 +873,53 @@ def reorder_schema(schema, child_order):
     """
     schema.children = [schema[node_name] for node_name in child_order]
     return schema
+
+
+def mk_choice_node_factory(base_node_factory, resource_name, **parent_kw):
+    """
+    Specialize a node factory using Select2Widget
+    to an item chooser among a list of items.
+
+    Typical use:  field in add/edit form (think ForeignKey)
+
+    :param function base_node_factory: a base node factory
+    :param resource_name str: the name of the resource to be selected
+      (used in widget strings and as default title)
+    """
+    def choice_node(**kw):
+        # if a keyword is defined in both parent call and choice_node call,
+        # priorize choice_node call (more specific).
+        for k, v in parent_kw.items():
+            kw.setdefault(k, v)
+
+        return base_node_factory(
+            widget_options={
+                'title': kw.get('title', resource_name),
+                'placeholder': u"- Sélectionner {} -".format(resource_name),
+                'default_option': ('', ''),  # required by placeholder
+            },
+            **kw
+        )
+    return choice_node
+
+
+def mk_filter_node_factory(base_node_factory, empty_filter_msg, **parent_kw):
+    """
+    Specialize a a node factory using Select2Widget
+    to a list filtering node factory.
+
+    :param function base_node_factory: a base node factory
+    :param empty_filter_msg str: the name of the list item for "no filter"
+      (used in widget strings)
+    """
+    def filter_node(**kw):
+        for k, v in parent_kw.items():
+            kw.setdefault(k, v)
+        return base_node_factory(
+            missing=colander.drop,
+            widget_options={
+                'default_option': ('', empty_filter_msg),
+            },
+            **kw
+        )
+    return filter_node

--- a/autonomie/forms/__init__.py
+++ b/autonomie/forms/__init__.py
@@ -864,7 +864,7 @@ def customize_field(schema, field_name, widget=None, validator=None, **kw):
 
 def reorder_schema(schema, child_order):
     """
-    reorder a schema folowwing the child_order
+    reorder a schema folowing the child_order
 
     :param obj schema: The colander schema :class:`colander.Schema`
     :param tuple child_order: The children order

--- a/autonomie/forms/accounting.py
+++ b/autonomie/forms/accounting.py
@@ -75,7 +75,7 @@ def deferred_analytical_account_widget(node, kw):
     ).order_by(AccountingOperation.analytical_account).all()
     datas = zip(*datas)[0]
     values = zip(datas, datas)
-    values.insert(0, ('', u'Filtrer par code analytique'))
+    values.insert(0, ('', u'Tous les codes analytiques'))
     return deform.widget.Select2Widget(values=values)
 
 
@@ -89,7 +89,7 @@ def deferred_general_account_widget(node, kw):
     ).order_by(AccountingOperation.general_account).all()
     datas = zip(*datas)[0]
     values = zip(datas, datas)
-    values.insert(0, ('', u'Filtrer par compte général'))
+    values.insert(0, ('', u'Tous les comptes généraux'))
     return deform.widget.Select2Widget(values=values)
 
 
@@ -103,7 +103,7 @@ def deferred_company_id_widget(node, kw):
     ).all()
     datas = zip(*datas)[0]
     values = DBSESSION().query(Company.id, Company.name).all()
-    values.insert(0, ('', u"Filtrer par entreprise"))
+    values.insert(0, ('', u"Toutes les  entreprises"))
     return deform.widget.Select2Widget(values=values)
 
 

--- a/autonomie/forms/activity.py
+++ b/autonomie/forms/activity.py
@@ -37,8 +37,13 @@ from autonomie.models.activity import (
     ATTENDANCE_STATUS,
     ATTENDANCE_STATUS_SEARCH,
 )
-from autonomie.forms.user import user_node
-from autonomie.forms.company import company_node
+from autonomie.forms.user import (
+    conseiller_choice_node,
+    conseiller_filter_node_factory,
+    participant_choice_node,
+    participant_filter_node_factory,
+)
+from autonomie.forms.company import company_choice_node
 from autonomie.models.task.invoice import get_invoice_years
 
 from autonomie import forms
@@ -116,24 +121,21 @@ class ParticipantsSequence(colander.SequenceSchema):
     """
     Schema for the list of participants
     """
-    participant_id = user_node(title=u"un participant", )
+    participant_id = participant_choice_node()
 
 
 class ConseillerSequence(colander.SequenceSchema):
     """
     Schema for the list of conseiller
     """
-    conseiller_id = user_node(
-        title=u"un conseiller",
-        roles=['manager', 'admin'],
-    )
+    conseiller_id = conseiller_choice_node()
 
 
 class CompanySequence(colander.SequenceSchema):
     """
     schema for the list of attached companies
     """
-    company_id = company_node(title=u"une entreprise")
+    company_id = company_choice_node()
 
 
 class CreateActivitySchema(colander.MappingSchema):
@@ -317,24 +319,8 @@ def get_list_schema(is_admin=False):
         missing=colander.drop))
 
     if is_admin:
-        schema.insert(0, user_node(
-            missing=colander.drop,
-            name='participant_id',
-            widget_options={
-                'default_option': ("", u"- Sélectionner un participant -"),
-            }
-            )
-        )
-
-        schema.insert(0, user_node(
-            roles=['manager', 'admin'],
-            missing=colander.drop,
-            name='conseiller_id',
-            widget_options={
-                'default_option': ("", u"- Sélectionner un conseiller -"),
-            }
-            )
-        )
+        schema.insert(0, participant_filter_node_factory(name='participant_id'))
+        schema.insert(0, conseiller_filter_node_factory(name='conseiller_id'))
 
     year = forms.year_select_node(
         name='year',

--- a/autonomie/forms/competence.py
+++ b/autonomie/forms/competence.py
@@ -21,7 +21,7 @@
 #    along with Autonomie.  If not, see <http://www.gnu.org/licenses/>.
 import colander
 
-from autonomie.forms.user import user_node
+from autonomie.forms.user import contractor_choice_node_factory
 from autonomie.models.competence import CompetenceDeadline
 
 
@@ -42,7 +42,7 @@ def deferred_deadline_id_validator(node, kw):
 
 
 class _CompetenceGridQuerySchema(colander.Schema):
-    contractor_id = user_node(roles=['contractor'])
+    contractor_id = contractor_choice_node_factory()
     deadline = colander.SchemaNode(
         colander.Integer(),
         validator=deferred_deadline_id_validator,

--- a/autonomie/forms/duplicate.py
+++ b/autonomie/forms/duplicate.py
@@ -30,7 +30,7 @@ from autonomie.models.customer import Customer
 from autonomie import forms
 from autonomie.forms.customer import (
     get_customers_from_request,
-    get_customer_select_node,
+    customer_choice_node_factory,
 )
 
 
@@ -121,11 +121,7 @@ class DuplicateSchema(colander.MappingSchema):
     """
     colander schema for duplication recording
     """
-    customer = get_customer_select_node(
-        title=u"Client",
-        default=deferred_default_customer,
-        with_default=False,
-    )
+    customer = customer_choice_node_factory()
     project = colander.SchemaNode(
         colander.Integer(),
         title=u"Projet",

--- a/autonomie/forms/expense.py
+++ b/autonomie/forms/expense.py
@@ -46,7 +46,7 @@ from autonomie.models.expense.types import (
     ExpenseType,
     ExpenseKmType,
 )
-from autonomie.forms.user import user_node
+from autonomie.forms.user import contractor_filter_node_factory
 from .custom_types import AmountType
 from autonomie import forms
 from autonomie.forms.payments import (
@@ -326,16 +326,6 @@ def get_list_schema():
         widget_options={'default_val': (-1, '')},
     ))
 
-    schema.insert(
-        0,
-        user_node(
-            title=u"Utilisateur",
-            missing=colander.drop,
-            name=u'owner_id',
-            widget_options={
-                'default_option': ('', u'Tous les entrepreneurs'),
-                'placeholder': u"Sélectionner un entrepreneur"},
-        )
-    )
+    schema.insert(0, contractor_filter_node_factory(name=u'owner_id'))
 
     return schema

--- a/autonomie/forms/export.py
+++ b/autonomie/forms/export.py
@@ -30,7 +30,7 @@ import deform
 
 from autonomie.models.expense.sheet import get_expense_years
 from autonomie.models.task.invoice import get_invoice_years
-from autonomie.forms.user import user_node
+from autonomie.forms.user import contractor_filter_node_factory
 
 from autonomie import forms
 
@@ -149,10 +149,7 @@ class ExpenseSchema(colander.MappingSchema):
     """
     Schema for sage expense export
     """
-    user_id = user_node(
-        title=u"Nom de l'entrepreneur",
-        widget_options={'default_option': (u'0', u'Tous les entrepreneurs',)}
-    )
+    user_id = contractor_filter_node_factory()
     year = forms.year_select_node(title=u"Année", query_func=get_expense_years)
     month = forms.month_select_node(title=u"Mois")
     exported = ExportedField()

--- a/autonomie/forms/holiday.py
+++ b/autonomie/forms/holiday.py
@@ -29,7 +29,7 @@ import colander
 import logging
 
 from deform import widget
-from autonomie.forms.user import user_node
+from autonomie.forms.user import contractor_filter_node_factory
 
 log = logging.getLogger(__name__)
 
@@ -59,11 +59,7 @@ class HolidaysSchema(colander.MappingSchema):
 class SearchHolidaysSchema(colander.MappingSchema):
     start_date = colander.SchemaNode(colander.Date(), title=u"Date de début")
     end_date = colander.SchemaNode(colander.Date(), title=u"Date de fin")
-    user_id = user_node(
-        title=u"Entrepreneur",
-        missing=colander.drop,
-        widget_options={'default_option': ('', u"Tous")}
-    )
+    user_id = contractor_filter_node_factory()
 
 
 searchSchema = SearchHolidaysSchema(

--- a/autonomie/forms/project/__init__.py
+++ b/autonomie/forms/project/__init__.py
@@ -43,7 +43,7 @@ from autonomie.models.project.types import (
 )
 from autonomie import forms
 from autonomie.forms.lists import BaseListsSchema
-from autonomie.forms.customer import get_customer_select_node
+from autonomie.forms.customer import customer_choice_node_factory
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +260,10 @@ def _add_customer_node_to_schema(schema):
     :param obj schema: a colander.SchemaNode instance
     """
     # Add a custom node to be able to associate existing customers
-    customer_id_node = get_customer_select_node(name="un client")
+    customer_id_node = customer_choice_node_factory(
+        name='customer_id',
+        title='un client',
+    )
     customer_id_node.objectify = customer_objectify
     customer_id_node.dictify = customer_dictify
 

--- a/autonomie/forms/tasks/base.py
+++ b/autonomie/forms/tasks/base.py
@@ -72,7 +72,7 @@ from autonomie.models.task import (
 )
 from autonomie.models.customer import Customer
 from autonomie.forms import today_node
-from autonomie.forms.customer import get_customer_select_node
+from autonomie.forms.customer import customer_choice_node_factory
 
 
 logger = logging.getLogger(__name__)
@@ -407,8 +407,7 @@ class NewTaskSchema(colander.Schema):
         default=deferred_default_name,
         missing="",
     )
-    customer_id = get_customer_select_node(
-        title=u"Choix du client",
+    customer_id = customer_choice_node_factory(
         default=deferred_default_customer,
         query_func=_get_customers_options,
     )
@@ -543,8 +542,7 @@ class DuplicateSchema(NewTaskSchema):
     """
     schema used to duplicate a task
     """
-    customer_id = get_customer_select_node(
-        title=u"Choix du client",
+    customer_id = customer_choice_node_factory(
         query_func=_get_customers_options,
         default=deferred_default_customer,
     )

--- a/autonomie/forms/tasks/estimation.py
+++ b/autonomie/forms/tasks/estimation.py
@@ -22,8 +22,8 @@ from autonomie.models.task.invoice import (
 
 from autonomie import forms
 from autonomie.forms.company import (
-    company_node,
-    customer_node,
+    company_filter_node_factory,
+    customer_filter_node_factory,
 )
 from autonomie.forms.custom_types import AmountType
 from autonomie.forms.tasks.lists import (
@@ -64,17 +64,13 @@ def get_list_schema(is_global=False, excludes=()):
     del schema['search']
 
     if 'customer' not in excludes:
-        schema.insert(0, customer_node(is_global))
+        schema.insert(0, customer_filter_node_factory(
+            is_admin=is_global,
+            name='customer_id',
+        ))
 
     if "company_id" not in excludes:
-        schema.insert(
-            0,
-            company_node(
-                name='company_id',
-                missing=colander.drop,
-                widget_options={'default': ('', u'Toutes les entreprises')}
-            )
-        )
+        schema.insert(0, company_filter_node_factory(name='company_id'))
 
     schema.insert(
         0,

--- a/autonomie/forms/tasks/invoice.py
+++ b/autonomie/forms/tasks/invoice.py
@@ -55,8 +55,8 @@ from autonomie.models.task.invoice import (
 from autonomie.utils.strings import format_amount
 from autonomie import forms
 from autonomie.forms.company import (
-    customer_node,
-    company_node,
+    customer_filter_node_factory,
+    company_filter_node_factory,
 )
 from autonomie.forms.custom_types import (
     AmountType,
@@ -278,16 +278,15 @@ def get_list_schema(is_global=False, excludes=()):
     )
 
     if 'customer' not in excludes:
-        schema.insert(0, customer_node(is_global))
+        schema.insert(0, customer_filter_node_factory(
+            is_admin=is_global,
+            name='customer_id',
+        ))
 
     if 'company_id' not in excludes:
         schema.insert(
             0,
-            company_node(
-                name='company_id',
-                missing=colander.drop,
-                widget_options={'default': ('', u'Toutes les entreprises')},
-            )
+            company_filter_node_factory(name='company_id')
         )
 
     schema.insert(

--- a/autonomie/forms/user/__init__.py
+++ b/autonomie/forms/user/__init__.py
@@ -6,6 +6,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import load_only
 
 from autonomie_base.models.base import DBSESSION
+from autonomie import forms
 from autonomie.utils.strings import (
     format_account,
 )
@@ -92,3 +93,38 @@ def user_node(roles=None, **kw):
         widget=get_deferred_user_choice(roles, widget_options),
         **kw
     )
+
+
+contractor_filter_node_factory = forms.mk_filter_node_factory(
+    user_node,
+    empty_filter_msg=u'Tous les travailleurs',
+    title=u'Travailleur',
+)
+
+conseiller_choice_node = forms.mk_choice_node_factory(
+    user_node,
+    resource_name=u"un conseiller",
+    roles=['manager', 'admin'],
+)
+
+conseiller_filter_node_factory = forms.mk_filter_node_factory(
+    user_node,
+    empty_filter_msg='Tous les conseillers',
+    roles=['manager', 'admin'],
+)
+
+participant_choice_node = forms.mk_choice_node_factory(
+    user_node,
+    resource_name=u"un participant",
+)
+
+participant_filter_node_factory = forms.mk_filter_node_factory(
+    user_node,
+    empty_filter_msg='Tous les participants',
+)
+
+contractor_choice_node_factory = forms.mk_choice_node_factory(
+    user_node,
+    resource_name="un entrepreneur",
+    roles=['contractor'],
+)

--- a/autonomie/forms/user/login.py
+++ b/autonomie/forms/user/login.py
@@ -197,6 +197,7 @@ def _deferred_group_widget(node, kw):
     return deform.widget.Select2Widget(
         values=groups,
         multiple=True,
+        placeholder=u'Aucun droit spécifique',
     )
 
 

--- a/autonomie/forms/user/userdatas.py
+++ b/autonomie/forms/user/userdatas.py
@@ -38,7 +38,7 @@ from autonomie.models.company import CompanyActivity
 from autonomie.forms.widgets import CleanMappingWidget
 from autonomie.forms.lists import BaseListsSchema
 from autonomie.forms.user import (
-    user_node,
+    conseiller_filter_node_factory,
     get_deferred_user_choice,
 )
 from autonomie.forms import (
@@ -358,17 +358,7 @@ def get_list_schema():
     )
     )
 
-    schema.insert(
-        0,
-        user_node(
-            roles=['manager', 'admin'],
-            missing=-1,
-            name='situation_follower_id',
-            widget_options={
-                'default_option': (-1, ''),
-                'placeholder': u"Sélectionner un conseiller"},
-        )
-    )
+    schema.insert(0, conseiller_filter_node_factory())
     return schema
 
 

--- a/autonomie/forms/workshop.py
+++ b/autonomie/forms/workshop.py
@@ -25,7 +25,7 @@ from deform import widget as deform_widget
 
 from autonomie.models.activity import ATTENDANCE_STATUS
 from autonomie.models.workshop import WorkshopAction
-from autonomie.forms.user import user_node
+from autonomie.forms.user import participant_filter_node_factory
 from autonomie.models.task.invoice import get_invoice_years
 from autonomie import forms
 from autonomie.forms import lists, activity
@@ -183,13 +183,7 @@ def get_list_schema(company=False):
     if not company:
         schema.insert(
             0,
-            user_node(
-                missing=colander.drop,
-                name='participant_id',
-                widget_options={
-                    'default_option': ('', u"- Sélectionner un participant -"),
-                    }
-            )
+            participant_filter_node_factory(name='participant_id')
         )
         notfilled_node = colander.SchemaNode(
             colander.Boolean(),


### PR DESCRIPTION
Préalable à #623 et lié à #514.

J'ai été au delà de mon but initial (qui était de juste faire un peu de ménage sur les widgets concernant les utilisateurs).

Je me suis rendu compte que les différents widgets de type Select2 présentaient des paramètres et des libellés par forcément cohérents entre eux. J'en ai profité pour mettre de l'ordre et favoriser que cet ordre persiste en fournissant des helpers pour formater les champs concernés. Ça a été l'occasion pour moi de bien comprendre le fonctionnement des widgets/SchemaNode, leurs liens avec les context, les deffered… etc).