### PR TITLE
Suite du lexique sur les personnes / utilisateurs

### DIFF
--- a/docs/source/lexique.rst
+++ b/docs/source/lexique.rst
@@ -28,6 +28,17 @@ code : une partie des ``User`` (+ ``UserData``), groupe ``contractor``
 
 Entrepreneur, qu'il soit en CAPE, ou en CESA. Inclut également les CDD.
 
+Accompagnateur
+--------------
+
+code: une partie des ``User`` (+ ``UserData``) : groupe ``manager``
+
+Personne de l'équipe d'appui faisant le suivi d'un entrepreneur.
+
+.. note:: Parfois appelée, selon la CAE *« chargée d'accompagnement »*, *«
+          conseiller »* ou *« chargé d'accompagnement »*.
+
+
 Enseigne
 --------
 
@@ -38,12 +49,3 @@ Nom commercial regroupant un ou plusieurs entrepreneurs.
 .. warning:: À éviter (source de confusion) : *« entreprise »* ou *« activité »*.
 
 
-Accompagnateur
---------------
-
-code: une partie des ``User`` (+ ``UserData``) : groupe ``manager``
-
-Personne de l'équipe d'appui faisant le suivi d'un entrepreneur.
-
-.. note:: Parfois appelée, selon la CAE *« chargée d'accompagnement »*, *«
-          conseiller »* ou *« chargé d'accompagnement »*.

--- a/docs/source/lexique.rst
+++ b/docs/source/lexique.rst
@@ -6,25 +6,27 @@ plusieurs mots pour désigner une même chose. Au sein d'autonomie, il est
 souhaitable d'utiliser un vocabulaire cohérent (toujours le même terme pour
 désigner la même chose).
 
-Les termes listés en titre de sections sont les **termes dont l'usage est recommandé**.
+Les termes listés en titre de sections sont les **termes dont l'usage est
+recommandé**.
 
-Salarié ou en CAPE
-------------------
+Travailleur
+------------
 
-code : une partie des ``User`` (+ ``UserData``)
+code : une partie des ``User`` (+ ``UserData``), réunion des groupes ``contractor`` et ``manager``.
 
-Inclut entrepreneurs salariés (en CESA, CDI, CDD ou CAPE), et équipe d'appui.
+Toute personne en contrat de travail ou CAPE avec la coopérative.
 
-.. note:: c'est un abus de langage assumé pour le CAPE qui n'est pas un contrat de travail.
+Inclut entrepreneurs salariés (en CESA, CDI, ou CAPE), CDD et équipe d'appui.
+
 .. warning:: À ne pas confondre avec *« salarié »* ou *« entrepreneur »*, «
              utilisateur » également n'a pas grand sens métier.
 
 Entrepreneur
 ------------
 
-code : une partie des ``User`` (+ ``UserData``)
+code : une partie des ``User`` (+ ``UserData``), groupe ``contractor``
 
-Entrepreneur, qu'il soit en CAPE, ou en CESA.
+Entrepreneur, qu'il soit en CAPE, ou en CESA. Inclut également les CDD.
 
 Enseigne
 --------
@@ -39,7 +41,7 @@ Nom commercial regroupant un ou plusieurs entrepreneurs.
 Accompagnateur
 --------------
 
-code: une partie des ``User`` (+ ``UserData``).
+code: une partie des ``User`` (+ ``UserData``) : groupe ``manager``
 
 Personne de l'équipe d'appui faisant le suivi d'un entrepreneur.
 

--- a/docs/source/lexique.rst
+++ b/docs/source/lexique.rst
@@ -9,6 +9,14 @@ désigner la même chose).
 Les termes listés en titre de sections sont les **termes dont l'usage est
 recommandé**.
 
+Personne
+--------
+
+code : `User`.
+
+Catégorie la plus large de personnes, englobe toutes **Travailleurs**,
+**Entrepreneurs**, et **Personne extérieure**.
+
 Travailleur
 ------------
 
@@ -38,6 +46,18 @@ Personne de l'équipe d'appui faisant le suivi d'un entrepreneur.
 .. note:: Parfois appelée, selon la CAE *« chargée d'accompagnement »*, *«
           conseiller »* ou *« chargé d'accompagnement »*.
 
+
+Personne extérieure
+-------------------
+
+Dans le code : ``User`` (+ ``UserData``) : groupe ``external``
+
+Personnes référencées dans autonomie comme ``User`` mais n'ayant pas forcément
+de lien contractuel long avec la coopérative. Ces personnes n'ont généralement
+pas d'identifiants pour se connecter à autonomie, mais on peut les inscrire à
+des Ateliers, ou elle peuvent être notées comme (co)-organisatrices d'ateliers.
+
+.. warning:: En chantier : le groupe ``external`` n'existe pas encore.
 
 Enseigne
 --------


### PR DESCRIPTION
Suite de #637 

Je n'avais pas bien compris « contractor », au début, j'ai donc corrigé. 

Notamment, et il convient de définir les utilisateurs externes également puisque c'est désormais possible avec #513 et nécessaire pour l'ouverture de la gestion des ateliers à tous les formateurs.