### PR TITLE
Fix #549 : Ajout du filtre 'Antenne' dans l'annuaire de gestion sociale

### DIFF
--- a/autonomie/alembic/versions/4_2_0_add_project_type_44f964dc36a2.py
+++ b/autonomie/alembic/versions/4_2_0_add_project_type_44f964dc36a2.py
@@ -164,9 +164,15 @@ where {type_}.course=1 and task.project_id=project.id ) > 0;"
     _add_business_to_all_invoices(session)
 
 
+def clean_database():
+    op.drop_column('estimation', 'course')
+    op.drop_column('invoice', 'course')
+
+
 def upgrade():
     update_database_structure()
     migrate_datas()
+    clean_database()
 
 
 def downgrade():

--- a/autonomie/forms/__init__.py
+++ b/autonomie/forms/__init__.py
@@ -510,7 +510,9 @@ def get_deferred_model_select_validator(model, id_key='id', filters=[]):
 get_deferred_select_validator = get_deferred_model_select_validator
 
 
-def get_model_select_option_values(model, keys, filters=(), add_default=True):
+def get_model_select_option_values(
+    model, keys, filters=(), add_default=True, empty_filter_msg=''
+):
     """
     Build an option list that can be used by SelectWidget and CheckboxListWidget
 
@@ -524,8 +526,8 @@ def get_model_select_option_values(model, keys, filters=(), add_default=True):
     key1, key2 = keys
 
     values = []
-    if add_default:
-        values.append(('', ''))
+    if add_default or empty_filter_msg:
+        values.append(('', empty_filter_msg))
 
     query = model.query()
     for key, value in filters:
@@ -546,7 +548,8 @@ def get_model_select_option_values(model, keys, filters=(), add_default=True):
 
 
 def get_deferred_model_select(
-    model, multi=False, mandatory=False, keys=('id', 'label'), filters=[]
+    model, multi=False, mandatory=False, keys=('id', 'label'), filters=[],
+    empty_filter_msg="",
 ):
     """
     Return a deferred select widget based on the given model
@@ -582,7 +585,8 @@ def get_deferred_model_select(
             model,
             keys,
             filters,
-            add_default=not mandatory
+            add_default=not mandatory,
+            empty_filter_msg=empty_filter_msg,
         )
         return deform.widget.SelectWidget(values=values, multi=multi)
     return deferred_widget

--- a/autonomie/views/userdatas/lists.py
+++ b/autonomie/views/userdatas/lists.py
@@ -93,6 +93,18 @@ class UserDatasListClass(object):
             )
         return query
 
+    def filter_situation_antenne_id(self, query, appstruct):
+        """
+        Filter the current query with antenne id
+        """
+        antenne_id = appstruct.get('situation_antenne_id')
+
+        if antenne_id not in (None, -1, colander.null):
+            query = query.filter(
+                UserDatas.situation_antenne_id == antenne_id
+            )
+        return query
+
 
 class UserDatasListView(UserDatasListClass, BaseListView):
     """


### PR DESCRIPTION
Ajoute le champ antenne dans les filtres de l'annuaire de gestion sociale
Utilise les outils de forms/__init__.py pour générer le formulaire servant pour le filtrage
Filtre les entrées en fonction de l'antenne sélectionnée