### PR TITLE
Fix 804 : Migration cassée

### DIFF
--- a/autonomie/alembic/versions/4_2_0_add_project_type_44f964dc36a2.py
+++ b/autonomie/alembic/versions/4_2_0_add_project_type_44f964dc36a2.py
@@ -68,6 +68,7 @@ def update_database_structure():
     op.create_foreign_key(
         op.f('fk_task_pdf_file_id'), 'task', 'file', ['pdf_file_id'], ['id']
     )
+    op.add_column('task', sa.Column('notes', sa.Text(), nullable=True))
 
 
 def _add_business_to_all_invoices(session):

--- a/autonomie/alembic/versions/4_2_0a0_add_task_s_notes_3885e8260693.py
+++ b/autonomie/alembic/versions/4_2_0a0_add_task_s_notes_3885e8260693.py
@@ -16,7 +16,8 @@ from autonomie.alembic.utils import column_exists
 
 
 def update_database_structure():
-    op.add_column('task', sa.Column('notes', sa.Text(), nullable=True))
+    if not column_exists('task', 'notes'):
+        op.add_column('task', sa.Column('notes', sa.Text(), nullable=True))
 
 
 def migrate_datas():


### PR DESCRIPTION
Migration depuis la 4.1
Pour éviter de générer des problèmes inutils (version en bdd ...), j'ai
ajouté un test sur column_exists.