### PR TITLE
Fix erreur dans les acls

### DIFF
--- a/autonomie/static/css/main.css
+++ b/autonomie/static/css/main.css
@@ -97,14 +97,15 @@ nav.sidebar-menu .subnav li {
   margin-top: 3px;
   margin-left: 3px;
   margin-bottom: 5px;
-  height: 36px;
+  max-height: 36px;
   padding: 0;
-  line-height: 36px;
+  line-height: 26px;
   list-style: none;
   background-color: #e6e9ed;
   white-space: nowrap;
   overflow: auto;
-  overflow-y: hidden; }
+  overflow-y: hidden;
+  font-size: 12px; }
 
 .breadcrumb-arrow li:first-child a {
   border-radius: 4px 0 0 4px;
@@ -125,9 +126,9 @@ nav.sidebar-menu .subnav li {
   padding: 0 10px; }
 
 .breadcrumb-arrow li a, .breadcrumb-arrow li:not(:first-child) span {
-  height: 36px;
+  height: 26px;
   padding: 0 10px 0 25px;
-  line-height: 36px; }
+  line-height: 26px; }
 
 .breadcrumb-arrow li:first-child a {
   padding: 0 10px; }
@@ -148,8 +149,8 @@ nav.sidebar-menu .subnav li {
   width: 0;
   height: 0;
   content: '';
-  border-top: 18px solid transparent;
-  border-bottom: 18px solid transparent; }
+  border-top: 13px solid transparent;
+  border-bottom: 13px solid transparent; }
 
 .breadcrumb-arrow li a:before {
   right: -10px;
@@ -165,7 +166,7 @@ nav.sidebar-menu .subnav li {
 
 .breadcrumb-arrow li a:focus, .breadcrumb-arrow li a:hover {
   background-color: #4fc1e9;
-  border: 1px solid #4fc1e9; }
+  border: 1px solid #breadcrumb-bkg-current-color; }
 
 .breadcrumb-arrow li a:focus:before, .breadcrumb-arrow li a:hover:before {
   border-left-color: #4fc1e9; }

--- a/autonomie/templates/project/layout.mako
+++ b/autonomie/templates/project/layout.mako
@@ -27,6 +27,7 @@
 </%block>
 <%block name='content'>
 <div class='panel panel-default page-block'>
+
     <div class='panel-heading'>
         <div class='row'>
             <div class='col-md-3 col-xs-12 bordered'>
@@ -36,6 +37,7 @@
                     </div>
                     <div class='col-md-9'>
                         <div>Projet : ${layout.current_project_object.name}</div>
+
                         <div class='help-text'>
                         % if layout.current_project_object.description:
                             ${layout.current_project_object.description}
@@ -44,7 +46,8 @@
                             ${layout.current_project_object.project_type.label}
                             % endif
                         </div>
-                <div class='pull-right'>
+
+                        <div class='pull-right'>
                         % if request.has_permission("edit.project", layout.current_project_object):
                         <a
                             class='btn btn-default btn-small pull-right'
@@ -59,15 +62,14 @@
                             >
                             <i class='fa fa-info-circle'></i>
                         </a>
-                        <div>
                         </div>
                     </div>
                 </div>
             </div>
             <div class='col-md-9 hidden-xs'>
-            <%block name='projecttitle'>
-                <div>Clients : ${','.join(layout.customer_labels)}</div>
-            </%block>
+                <%block name='projecttitle'>
+                    <div>Clients : ${','.join(layout.customer_labels)}</div>
+                </%block>
             </div>
         </div>
     </div>

--- a/autonomie/templates/project/layout.mako
+++ b/autonomie/templates/project/layout.mako
@@ -47,6 +47,13 @@
                             % endif
                         </div>
 
+                    </div>
+                </div>
+            </div>
+            <div class='col-md-9 hidden-xs'>
+                <%block name='projecttitle'>
+                    <div>Clients : ${','.join(layout.customer_labels)}</div>
+                </%block>
                         <div class='pull-right'>
                         % if request.has_permission("edit.project", layout.current_project_object):
                         <a
@@ -63,13 +70,6 @@
                             <i class='fa fa-info-circle'></i>
                         </a>
                         </div>
-                    </div>
-                </div>
-            </div>
-            <div class='col-md-9 hidden-xs'>
-                <%block name='projecttitle'>
-                    <div>Clients : ${','.join(layout.customer_labels)}</div>
-                </%block>
             </div>
         </div>
     </div>

--- a/autonomie/templates/tasks/estimation_view_only.mako
+++ b/autonomie/templates/tasks/estimation_view_only.mako
@@ -83,11 +83,9 @@
 % endif
 </%block>
 
-<%block name='before_actions'>
+<%block name='panel_heading'>
     <% estimation = request.context %>
-    <h2>
     ${estimation.name}
-    </h2>
 </%block>
 <%block name='before_summary'>
 <br />

--- a/autonomie/utils/security.py
+++ b/autonomie/utils/security.py
@@ -904,28 +904,28 @@ def get_task_line_group_acl(self):
     """
     Return the task line acl
     """
-    return self.task.__acl__
+    return self.task.__acl__()
 
 
 def get_task_line_acl(self):
     """
     Return the task line acl
     """
-    return self.group.__acl__
+    return self.group.__acl__()
 
 
 def get_discount_line_acl(self):
     """
     Return the acls for accessing the discount line
     """
-    return self.task.__acl__
+    return self.task.__acl__()
 
 
 def get_payment_line_acl(self):
     """
     Return the acls for accessing a payment line
     """
-    return self.task.__acl__
+    return self.task.__acl__()
 
 
 def get_expense_sheet_default_acl(self):
@@ -1150,16 +1150,19 @@ def get_file_acl(self):
     Compute the acl for a file object
     a file object's acl are simply the parent's
     """
+    acl = []
     if self.parent is not None:
-        return self.parent.__acl__
+        acl = self.parent.__acl__
     # Exceptions: headers and logos are not attached throught the Node's parent
     # rel
     elif self.company_header_backref is not None:
-        return self.company_header_backref.__acl__
+        acl = self.company_header_backref.__acl__
     elif self.company_logo_backref is not None:
-        return self.company_logo_backref.__acl__
-    else:
-        return []
+        acl = self.company_logo_backref.__acl__
+
+    if acl and callable(acl):
+        acl = acl()
+    return acl
 
 
 def get_product_acl(self):
@@ -1205,9 +1208,12 @@ def get_accounting_measure_acl(self):
     Compile the default acl for TreasuryMeasureGrid and
     IncomeStatementMeasureGrid objects
     """
+    acl = []
     if self.company is not None:
-        return self.company.__acl__
-    return []
+        acl = self.company.__acl__
+        if callable(acl):
+            acl = acl()
+    return acl
 
 
 def get_indicator_acl(self):

--- a/css_sources/main/breadcrumb.scss
+++ b/css_sources/main/breadcrumb.scss
@@ -5,14 +5,15 @@
    margin-top: 3px;
    margin-left: 3px;
    margin-bottom: 5px;
-    height: 36px;
+    max-height: 36px;
     padding: 0;
-    line-height: 36px;
+    line-height: 26px;
     list-style: none;
     background-color: $breadcrumb-bkg-color;
     white-space: nowrap;
     overflow: auto;
 overflow-y: hidden;
+font-size: 12px;
 }
 .breadcrumb-arrow li:first-child a {
     border-radius: 4px 0 0 4px;
@@ -33,9 +34,9 @@ overflow-y: hidden;
     padding: 0 10px
 }
 .breadcrumb-arrow li a, .breadcrumb-arrow li:not(:first-child) span {
-    height: 36px;
+    height: 26px;
     padding: 0 10px 0 25px;
-    line-height: 36px
+    line-height: 26px
 }
 .breadcrumb-arrow li:first-child a {
     padding: 0 10px
@@ -44,8 +45,8 @@ overflow-y: hidden;
     position: relative;
     color: #fff;
     text-decoration: none;
-    background-color: #3bafda;
-    border: 1px solid #3bafda
+    background-color: $breadcrumb-bkg-parent-color;
+    border: 1px solid $breadcrumb-bkg-parent-color;
 }
 .breadcrumb-arrow li:first-child a {
     padding-left: 10px
@@ -56,25 +57,25 @@ overflow-y: hidden;
     width: 0;
     height: 0;
     content: '';
-    border-top: 18px solid transparent;
-    border-bottom: 18px solid transparent
+    border-top: 13px solid transparent;
+    border-bottom: 13px solid transparent
 }
 .breadcrumb-arrow li a:before {
     right: -10px;
     z-index: 3;
-    border-left-color: #3bafda;
+    border-left-color: $breadcrumb-bkg-parent-color;
     border-left-style: solid;
     border-left-width: 11px
 }
 .breadcrumb-arrow li a:after {
     right: -11px;
     z-index: 2;
-    border-left: 11px solid #2494be
+    border-left: 11px solid #2494be;
 }
 .breadcrumb-arrow li a:focus, .breadcrumb-arrow li a:hover {
-    background-color: #4fc1e9;
-    border: 1px solid #4fc1e9
+    background-color: $breadcrumb-bkg-current-color;
+    border: 1px solid #breadcrumb-bkg-current-color;
 }
 .breadcrumb-arrow li a:focus:before, .breadcrumb-arrow li a:hover:before {
-    border-left-color: #4fc1e9
+    border-left-color: $breadcrumb-bkg-current-color;
 }

--- a/css_sources/main/colors.scss
+++ b/css_sources/main/colors.scss
@@ -9,6 +9,8 @@ $footer-bkg-color: #2f4050;
 $bkg-color: #f5f5f6;
 $bkg-color-dark: #d5d5d6;
 $breadcrumb-bkg-color: #e6e9ed;
+$breadcrumb-bkg-parent-color: #3bafda;
+$breadcrumb-bkg-current-color: #4fc1e9;
 
 $panel-heading-color: #fff;
 


### PR DESCRIPTION
Un peu de design et surtout

Fix #836 : Erreurs multiples dans les acls
    
    Le passage d'acl sous forme de property vers des acls sour forme de
    callable PR #811 (bug #810) a introduit des erreurs dans le cas des acls
    "forwardées"
    
    a.__acl__ = lambda self: "acl de a"
    b.__acl__ = lambda self: a.__acl__
    
    b.__acl__() est une lambda
    
    alors qu'auparavant
    
    b.__acl__ renvoyait "acl de a"
