### PR TITLE
Fix #772 : déplacement des éléments liés

### DIFF
--- a/autonomie/forms/tasks/base.py
+++ b/autonomie/forms/tasks/base.py
@@ -533,7 +533,7 @@ def get_task_metadatas_edit_schema():
     schema['project_id'].widget = deferred_customer_project_widget
     schema['project_id'].title = u"Projet vers lequel déplacer ce document"
     schema['phase_id'].title = u"Dossier dans lequel déplacer ce document"
-    schema['business_type_id'].widget = deform.widget.HiddenWidget()
+    del schema['business_type_id']
     schema.after_bind = add_date_field_after_bind
     return schema
 

--- a/autonomie/models/project/business.py
+++ b/autonomie/models/project/business.py
@@ -216,3 +216,12 @@ class Business(Node):
         return self._autonomie_service.find_deadline_from_invoice(
             self, invoice
         )
+
+    def is_visible(self):
+        """
+        Check if this business should be shown to the end user (if it's parent
+        project is not of default type)
+
+        :rtype: bool
+        """
+        return not self._autonomie_service.is_default_project_type(self)

--- a/autonomie/models/services/business.py
+++ b/autonomie/models/services/business.py
@@ -156,3 +156,27 @@ class BusinessService:
             DBSESSION().merge(deadline)
             invoices.append(invoice)
         return invoices
+
+    @classmethod
+    def is_default_project_type(cls, business):
+        """
+        Check if the parent's project type is of type default
+
+        :param obj business: The current business instance this service is
+        attached to
+        :rtype: bool
+        """
+        from autonomie.models.project.project import Project
+        from autonomie.models.project.types import ProjectType
+        project_type_id = DBSESSION().query(
+            Project.project_type_id
+        ).filter_by(
+            id=business.project_id
+        ).scalar()
+
+        ptype_name = DBSESSION().query(
+            ProjectType.name
+        ).filter_by(
+            id=project_type_id
+        ).scalar()
+        return ptype_name == u"default"

--- a/autonomie/static/css/main.css
+++ b/autonomie/static/css/main.css
@@ -322,7 +322,8 @@ ul.form-tabs li.error a {
 
 .btn {
   font-size: 0.95rem;
-  border-radius: 0px; }
+  border-radius: 0px;
+  overflow-x: hidden; }
   .btn.btn-head {
     margin-bottom: 15px !important; }
   .btn.primary-action {

--- a/autonomie/tests/models/services/test_business.py
+++ b/autonomie/tests/models/services/test_business.py
@@ -57,3 +57,12 @@ def test_gen_invoices_all(business, full_estimation, user):
     assert len(invoices) == 3
     for i in range(2):
         assert business.payment_deadlines[i].invoice == invoices[i]
+
+
+def test_is_visible(dbsession, business, project, mk_project_type):
+    business.project = project
+    dbsession.merge(business)
+    assert BusinessService.is_default_project_type(business) == True
+    project.project_type = mk_project_type(name="newone")
+    dbsession.merge(project)
+    assert BusinessService.is_default_project_type(business) == False

--- a/autonomie/tests/views/task/conftest.py
+++ b/autonomie/tests/views/task/conftest.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+# * Authors:
+#       * TJEBBES Gaston <g.t@majerti.fr>
+#       * Arezki Feth <f.a@majerti.fr>;
+#       * Miotte Julien <j.m@majerti.fr>;
+import pytest
+
+
+@pytest.fixture
+def invoice_base_config(dbsession):
+    from autonomie.models.config import Config
+    Config.set('invoice_number_template', '{SEQYEAR}')
+
+
+@pytest.fixture
+def product_without_tva(dbsession):
+    from autonomie.models.tva import Product
+    product = Product(name='product', compte_cg='122')
+    dbsession.add(product)
+    dbsession.flush()
+    return product
+
+
+@pytest.fixture
+def task_line_group(dbsession):
+    from autonomie.models.task.task import TaskLineGroup
+    group = TaskLineGroup(
+        order=1,
+        title=u"Group title",
+        description=u"Group description",
+    )
+    dbsession.add(group)
+    dbsession.flush()
+    return group
+
+
+@pytest.fixture
+def mk_task_line(dbsession, unity, tva, product, task_line_group):
+    from autonomie.models.task import TaskLine
+
+    def make(
+        cost, description=u"description", unity_label=unity.label, quantity=1,
+        tva_value=tva.value, group=task_line_group, product=product,
+    ):
+        line = TaskLine(
+            cost=cost,
+            quantity=quantity,
+            unity=unity_label,
+            tva=tva_value,
+            product_id=product.id,
+            group=group,
+        )
+        dbsession.add(line)
+        dbsession.flush()
+        return line
+    return make
+
+
+@pytest.fixture
+def task_line(mk_task_line, tva, product):
+    # TTC = 120 €
+    return mk_task_line(cost=10000000, tva_value=tva.value, product=product)
+
+
+@pytest.fixture
+def discount_line(dbsession, tva):
+    from autonomie.models.task.task import DiscountLine
+    discount = DiscountLine(
+        description="Discount", amount=1000000, tva=tva.value
+    )
+    dbsession.add(discount)
+    dbsession.flush()
+    return discount
+
+
+@pytest.fixture
+def payment_line(dbsession):
+    from autonomie.models.task.estimation import PaymentLine
+    payment_line = PaymentLine(
+        amount=15000000,
+        description=u"Payment Line",
+    )
+    dbsession.add(payment_line)
+    dbsession.flush()
+    return payment_line
+
+
+@pytest.fixture
+def payment_line2(dbsession):
+    from autonomie.models.task.estimation import PaymentLine
+    payment_line = PaymentLine(
+        amount=10000000,
+        description=u"Payment Line 2",
+    )
+    dbsession.add(payment_line)
+    dbsession.flush()
+    return payment_line
+
+
+@pytest.fixture
+def estimation(
+    dbsession,
+    tva,
+    unity,
+    project,
+    customer,
+    company,
+    user,
+    phase,
+):
+    from autonomie.models.task.estimation import Estimation
+    estimation = Estimation(
+        company=company,
+        project=project,
+        customer=customer,
+        phase=phase,
+        user=user,
+    )
+    dbsession.add(estimation)
+    dbsession.flush()
+    return estimation
+
+
+@pytest.fixture
+def mk_invoice(
+    dbsession,
+    tva,
+    unity,
+    project,
+    customer,
+    company,
+    user,
+    phase,
+):
+    def _mk_invoice(date=None, company=company):
+        from autonomie.models.task.invoice import Invoice
+        invoice = Invoice(
+            company=company,
+            project=project,
+            customer=customer,
+            phase=phase,
+            user=user,
+            date=date,
+        )
+        dbsession.add(invoice)
+        dbsession.flush()
+        return invoice
+    return _mk_invoice
+
+
+@pytest.fixture
+def invoice(mk_invoice):
+    return mk_invoice()
+
+
+@pytest.fixture
+def cancelinvoice(
+    dbsession,
+    tva,
+    unity,
+    project,
+    customer,
+    company,
+    user,
+    phase,
+):
+    from autonomie.models.task.invoice import CancelInvoice
+    cancelinvoice = CancelInvoice(
+        company=company,
+        project=project,
+        customer=customer,
+        phase=phase,
+        user=user,
+    )
+    dbsession.add(cancelinvoice)
+    dbsession.flush()
+    return cancelinvoice
+
+
+@pytest.fixture
+def full_estimation(
+    dbsession, estimation, task_line_group, task_line, user, mention,
+    discount_line, payment_line, payment_line2, mk_task_line, mk_tva, mk_product
+):
+    tva = mk_tva(name="7%", value=700, default=False)
+    product = mk_product(name='product7', tva=tva)
+    # TTC  : 100 + 20/100 * 100 + 100 + 7%*100 - 12  + 12 €
+    # accompte : 10/100
+    # payments : 1er paiement de 150 + solde
+    task_line_group.lines = [
+        task_line,
+        mk_task_line(cost=10000000, tva_value=700, product=product)
+    ]
+    estimation.deposit = 10
+    estimation.line_groups = [task_line_group]
+    estimation.discounts = [discount_line]
+    estimation.payment_lines = [payment_line, payment_line2]
+    estimation.workplace = u'workplace'
+    estimation.mentions = [mention]
+    estimation.expenses_ht = 1000000
+    estimation = dbsession.merge(estimation)
+    estimation.manualDeliverables = 1
+    dbsession.flush()
+    return estimation
+
+
+@pytest.fixture
+def full_invoice(
+    dbsession, invoice, task_line_group, task_line, user, mention, discount_line
+):
+    # TTC  : 120 - 12  + 12 €
+    task_line_group.lines = [task_line]
+    invoice.line_groups = [task_line_group]
+    invoice.discounts = [discount_line]
+    invoice.workplace = u'workplace'
+    invoice.mentions = [mention]
+    invoice.expenses_ht = 1000000
+    invoice = dbsession.merge(invoice)
+    dbsession.flush()
+    return invoice
+
+
+@pytest.fixture
+def business(dbsession, full_estimation, default_business_type):
+    from autonomie.models.project.business import Business
+
+    business = Business(name="business", business_type=default_business_type)
+    business.estimations = [full_estimation]
+    dbsession.add(business)
+    dbsession.flush()
+    full_estimation.business_type_id = default_business_type.id
+    full_estimation.businesses = [business]
+    dbsession.merge(full_estimation)
+    return business

--- a/autonomie/tests/views/task/test_views.py
+++ b/autonomie/tests/views/task/test_views.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# * Authors:
+#       * TJEBBES Gaston <g.t@majerti.fr>
+#       * Arezki Feth <f.a@majerti.fr>;
+#       * Miotte Julien <j.m@majerti.fr>;
+from pyramid.httpexceptions import HTTPFound
+
+
+def test_task_metadata_view(
+    dbsession, full_estimation, config,
+    get_csrf_request_with_db
+):
+    from autonomie.views.task.views import TaskSetMetadatasView
+    original_customer_id = full_estimation.customer_id
+    appstruct = {
+        'name': 'new task name',
+        'customer_id': original_customer_id + 1,
+        'project_id': full_estimation.project_id,
+        'phase_id': full_estimation.phase_id,
+    }
+    request = get_csrf_request_with_db(post=appstruct, context=full_estimation)
+    config.add_route('/estimations/{id}', '/estimations/{id}')
+    view = TaskSetMetadatasView(full_estimation, request)
+    result = view.submit_success(appstruct)
+    assert isinstance(result, HTTPFound)
+    assert full_estimation.name == 'new task name'
+    assert full_estimation.customer_id == original_customer_id
+
+
+def test_task_metadata_set_estimatinon_project_id_view(
+    dbsession, full_estimation, config,
+    get_csrf_request_with_db, mk_project, full_invoice, business
+):
+    new_project = mk_project(name='project 2')
+    full_estimation.business = business
+    business.invoices.append(full_invoice)
+
+    from autonomie.views.task.views import TaskSetMetadatasView
+    appstruct = {
+        'name': 'new task name',
+        'customer_id': full_estimation.customer_id,
+        'project_id': new_project.id,
+    }
+    request = get_csrf_request_with_db(post=appstruct, context=full_estimation)
+    config.add_route('/estimations/{id}', '/estimations/{id}')
+    view = TaskSetMetadatasView(full_estimation, request)
+    result = view.submit_success(appstruct)
+    assert isinstance(result, HTTPFound)
+    assert full_estimation.project_id == new_project.id
+    assert business.project_id == new_project.id
+    assert full_invoice.project_id == new_project.id
+
+
+def test_task_metadata_set_invoice_project_id_view(
+    dbsession, full_estimation, config,
+    get_csrf_request_with_db, mk_project, full_invoice, business
+):
+    new_project = mk_project(name='project 2')
+    full_invoice.business = business
+    business.estimations.append(full_estimation)
+
+    from autonomie.views.task.views import TaskSetMetadatasView
+    appstruct = {
+        'name': 'new task name',
+        'customer_id': full_invoice.customer_id,
+        'project_id': new_project.id,
+    }
+    request = get_csrf_request_with_db(post=appstruct, context=full_invoice)
+    config.add_route('/invoices/{id}', '/invoices/{id}')
+    view = TaskSetMetadatasView(full_invoice, request)
+    result = view.submit_success(appstruct)
+    assert isinstance(result, HTTPFound)
+    assert full_estimation.project_id == new_project.id
+    assert business.project_id == new_project.id
+    assert full_invoice.project_id == new_project.id

--- a/css_sources/main/button.scss
+++ b/css_sources/main/button.scss
@@ -1,6 +1,7 @@
 .btn{
   font-size: 0.95rem;
   border-radius: 0px;
+  overflow-x: hidden;
   // Button placed at the top of a page
   &.btn-head{
     margin-bottom: 15px !important;

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyramid-layout==1.0
 pyramid-mailer==0.14.1
 pyramid-mako==1.0.2
 pyramid-methodrewrite==0.2.3
-pyramid_services
+pyramid_services=1.1
 pyramid-tm==2.2
 reportlab==3.1.44
 repoze.lru==0.6


### PR DESCRIPTION
Lors du déplacement d'un document (un devis/une facture/un avoir), on s'assure que les éléments liés (affaires, devis, factures, avoirs) sont bien déplacés également.