### PR TITLE
Fix #845 : Upddate de la version autonomie_base vers la version publiée

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic==0.8.2
-autonomie_base==4.2.0a1
+autonomie_base==4.2.0
 autonomie_celery==4.2.0a5
 Beaker==1.6.4
 bleach==3.0.2


### PR DESCRIPTION
La version 4.2.0 a été publiée
https://pypi.org/project/autonomie_base/