### PR TITLE
Ajout d'un devis à une affaire existante + surbrillance dans les menus + on cache les éléments

### DIFF
--- a/autonomie/alembic/versions/4_2_0_added_general_customer_account_third__5362502b508c.py
+++ b/autonomie/alembic/versions/4_2_0_added_general_customer_account_third__5362502b508c.py
@@ -1,4 +1,4 @@
-"""Added general_customer_account, third_party_customer_account, bank_account column to company
+"""4.2.0 : Added general_customer_account, third_party_customer_account, bank_account column to company
 
 Revision ID: 5362502b508c
 Revises: 4f011ed2a459
@@ -8,7 +8,7 @@ Create Date: 2018-10-26 17:37:20.149975
 
 # revision identifiers, used by Alembic.
 revision = '5362502b508c'
-down_revision = '4f011ed2a459'
+down_revision = 'd777c5e2750'
 
 from alembic import op
 import sqlalchemy as sa

--- a/autonomie/forms/company.py
+++ b/autonomie/forms/company.py
@@ -187,26 +187,26 @@ class CompanySchema(colander.MappingSchema):
 comptabilité",
             missing="")
 
-    general_customer_account = colander.SchemaNode(
-        colander.String(),
-        title=u"Compte client général",
-        description="",
-        missing="",
-    )
+    # general_customer_account = colander.SchemaNode(
+    #     colander.String(),
+    #     title=u"Compte client général",
+    #     description="",
+    #     missing="",
+    # )
 
-    third_party_customer_account = colander.SchemaNode(
-        colander.String(),
-        title=u"Compte client tiers",
-        description="",
-        missing="",
-    )
+    # third_party_customer_account = colander.SchemaNode(
+    #     colander.String(),
+    #     title=u"Compte client tiers",
+    #     description="",
+    #     missing="",
+    # )
 
-    bank_account = colander.SchemaNode(
-        colander.String(),
-        title=u"Compte de banque",
-        description="",
-        missing="",
-    )
+    # bank_account = colander.SchemaNode(
+    #     colander.String(),
+    #     title=u"Compte de banque",
+    #     description="",
+    #     missing="",
+    # )
 
     custom_insurance_rate = colander.SchemaNode(
             QuantityType(),
@@ -218,10 +218,12 @@ comptabilité",
                 min=0,
                 max=100,
                 min_err=u"Veuillez fournir un nombre supérieur à 0",
-                max_err=u"Veuillez fournir un nombre inférieur à 100"),
+                max_err=u"Veuillez fournir un nombre inférieur à 100"
+            ),
             title=u"Taux de Responsabilité Civile Professionnel",
             missing=colander.drop,
-            description=u"Pourcentage du taux d'assurance professionnelle de cette entreprise dans la CAE",
+            description=u"Pourcentage du taux d'assurance professionnelle "
+                        u"de cette entreprise dans la CAE",
     )
 
     contribution = colander.SchemaNode(

--- a/autonomie/models/project/business.py
+++ b/autonomie/models/project/business.py
@@ -225,3 +225,12 @@ class Business(Node):
         :rtype: bool
         """
         return not self._autonomie_service.is_default_project_type(self)
+
+    def add_estimation(self, user):
+        """
+        Generate a new estimation attached to the current business
+
+        :param obj user: The user generating the estimation
+        :rtype: class autonomie.models.task.estimation.Estimation
+        """
+        return self._autonomie_service.add_estimation(self, user)

--- a/autonomie/models/services/business.py
+++ b/autonomie/models/services/business.py
@@ -180,3 +180,45 @@ class BusinessService:
             id=project_type_id
         ).scalar()
         return ptype_name == u"default"
+
+    @classmethod
+    def add_estimation(cls, business, user):
+        """
+        Add a new estimation to the current business
+
+        :param obj business: The current business instance this service is
+        attached to
+        :returns: A new Estimation instance
+        """
+        from autonomie.models.task.estimation import Estimation
+        estimation = Estimation(
+            user=user,
+            company=business.project.company,
+            project=business.project,
+            customer_id=cls._get_customer_id(business),
+            business_id=business.id,
+            business_type_id=business.business_type_id,
+        )
+        estimation.add_default_payment_line()
+        estimation.initialize_business_datas()
+        DBSESSION().add(estimation)
+        DBSESSION().flush()
+        return estimation
+
+    @classmethod
+    def _get_customer_id(cls, business):
+        """
+        Find the customer associated to this bussiness
+
+        :param obj business: The business instance this service is attached to
+        :returns: A Customer id
+        :rtype: int
+        """
+        from autonomie.models.task import Task
+        result = DBSESSION().query(Task.customer_id).filter_by(
+            business_id=business.id
+        ).first()
+        if result:
+            return result[0]
+        else:
+            return None

--- a/autonomie/models/task/estimation.py
+++ b/autonomie/models/task/estimation.py
@@ -54,18 +54,12 @@ from autonomie.compute.task import (
     EstimationCompute,
 )
 from autonomie.compute.math_utils import integer_to_amount
-from autonomie.models.tva import Product
 from autonomie.interfaces import (
     IMoneyTask,
 )
 from autonomie.models.services.estimation import EstimationInvoicingService
-from .invoice import (
-    Invoice,
-)
 from .task import (
     Task,
-    TaskLine,
-    TaskLineGroup,
     TaskStatus,
 )
 from .actions import (
@@ -335,6 +329,10 @@ class Estimation(Task, EstimationCompute):
             return self._invoicing_service.gen_intermediate_invoice(
                 self, payment_line, user
             )
+
+    def add_default_payment_line(self):
+        self.payment_lines = [PaymentLine(description='Solde', amount=0)]
+        return self
 
 
 class PaymentLine(DBBASE):

--- a/autonomie/panels/menu.py
+++ b/autonomie/panels/menu.py
@@ -56,12 +56,7 @@ class Item(dict):
 
     def selected(self, request):
         href = self.get('href')
-
-        if href in request.current_route_path():
-            return True
-        else:
-            return False
-
+        return href == request.current_route_path(_query={})
 
 class HtmlItem(dict):
     """

--- a/autonomie/templates/base/utils.mako
+++ b/autonomie/templates/base/utils.mako
@@ -172,12 +172,13 @@
             % if request.has_permission('admin_treasury'):
                 <dt>Code comptable</dt>
                 <dd>${company.code_compta or u"Non renseigné"}</dd>
-                <dt>Compte client général</dt>
+                <!-- <dt>Compte client général</dt>
                 <dd>${company.general_customer_account or u"Non renseigné"}</dd>
                 <dt>Compte client tiers</dt>
                 <dd>${company.third_party_customer_account or u"Non renseigné"}</dd>
                 <dt>Compte de banque</dt>
                 <dd>${company.bank_account or u"Non renseigné"}</dd>
+                -->
                 <dt>Taux d'assurance professionnelle</dt>
                 <dd>${company.custom_insurance_rate or u"Non renseigné"}</dd>
                 <dt>Contribution à la CAE (en %)</dt>

--- a/autonomie/templates/business/overview.mako
+++ b/autonomie/templates/business/overview.mako
@@ -33,7 +33,7 @@
                 <a
                     href="${invoice_all_url}"
                     % if not business.invoiced:
-                    class='btn btn-primary primary-action'
+                    class='btn btn-primary'
                     % else:
                     class='btn btn-primary'
                     % endif
@@ -45,6 +45,13 @@
                     Générer toutes les factures
                     % endif
                 </a>
+                    <a
+                        href="${estimation_add_url}"
+                        class='btn btn-primary'
+                        >
+                        <i class='fa fa-plus-circle'></i>&nbsp;
+                        Créer un devis
+                    </a>
                 % endif
                 <h3>Devis de référence</h3>
                 % if not estimations:

--- a/autonomie/tests/models/services/test_business.py
+++ b/autonomie/tests/models/services/test_business.py
@@ -66,3 +66,8 @@ def test_is_visible(dbsession, business, project, mk_project_type):
     project.project_type = mk_project_type(name="newone")
     dbsession.merge(project)
     assert BusinessService.is_default_project_type(business) == False
+
+
+def test_get_customer_id(business, full_estimation):
+    result = BusinessService._get_customer_id(business)
+    assert result == full_estimation.customer_id

--- a/autonomie/views/business/business.py
+++ b/autonomie/views/business/business.py
@@ -23,6 +23,7 @@ from autonomie.views.business.routes import (
     BUSINESS_ITEM_OVERVIEW_ROUTE,
     BUSINESS_ITEM_INVOICING_ROUTE,
     BUSINESS_ITEM_INVOICING_ALL_ROUTE,
+    BUSINESS_ITEM_ESTIMATION_ROUTE,
 )
 from autonomie.views.project.project import ProjectEntryPointView
 
@@ -110,9 +111,26 @@ class BusinessOverviewView(BaseView, TreeMixin):
 
     # Lié à la vue elle-même
     def invoice_all_url(self):
+        """
+        Build the url used to generate all invoices
+
+        :rtype: str
+        """
         return self.request.route_path(
             BUSINESS_ITEM_INVOICING_ALL_ROUTE,
             id=self.context.id,
+        )
+
+    def estimation_add_url(self):
+        """
+        Build the estimation add url
+
+        :rtype: str
+        """
+        return self.request.route_path(
+            BUSINESS_ITEM_ESTIMATION_ROUTE,
+            id=self.context.id,
+            _query={'action': 'add'}
         )
 
     def __call__(self):
@@ -131,6 +149,7 @@ class BusinessOverviewView(BaseView, TreeMixin):
             invoice_all_url=self.invoice_all_url(),
             payment_deadlines=self.context.payment_deadlines,
             invoice_deadline_route=BUSINESS_ITEM_INVOICING_ROUTE,
+            estimation_add_url=self.estimation_add_url(),
         )
 
 

--- a/autonomie/views/business/estimation.py
+++ b/autonomie/views/business/estimation.py
@@ -3,12 +3,14 @@
 #       * TJEBBES Gaston <g.t@majerti.fr>
 #       * Arezki Feth <f.a@majerti.fr>;
 #       * Miotte Julien <j.m@majerti.fr>;
-
+from pyramid.httpexceptions import HTTPFound
 from autonomie.models.task import Estimation
 from autonomie.forms.tasks.estimation import get_list_schema
 from autonomie.views.estimations.lists import CompanyEstimationList
 from autonomie.views import TreeMixin
-from autonomie.views.business.routes import BUSINESS_ITEM_ESTIMATION_ROUTE
+from autonomie.views.business.routes import (
+    BUSINESS_ITEM_ESTIMATION_ROUTE,
+)
 from autonomie.views.project.business import ProjectBusinessListView
 from autonomie.views.business.business import (
     remember_navigation_history,
@@ -50,6 +52,19 @@ class BusinessEstimationList(CompanyEstimationList, TreeMixin):
         return query
 
 
+def add_estimation_view(context, request):
+    """
+    View used to add an estimation to the current business
+    """
+    estimation = context.add_estimation(request.user)
+    return HTTPFound(
+        request.route_path(
+            "/estimations/{id}",
+            id=estimation.id
+        )
+    )
+
+
 def includeme(config):
     config.add_tree_view(
         BusinessEstimationList,
@@ -57,4 +72,11 @@ def includeme(config):
         renderer="project/estimations.mako",
         permission="list.estimations",
         layout="business"
+    )
+    config.add_view(
+        add_estimation_view,
+        route_name=BUSINESS_ITEM_ESTIMATION_ROUTE,
+        permission="add.estimation",
+        request_param="action=add",
+        layout="default"
     )


### PR DESCRIPTION
- Ajoute un bouton et une vue pour la construction d'un devis depuis une affaire existante
- Renomme le script alembic de migration des Company (ajout de champs comptables) et cache les informations dans les formulaires et vue (seulement nécessaire pour les migrations depuis winscop pour l'instant)
- Meilleure gestion de la surbrillance des menus.