### PR TITLE
#944 droits de consultation feuille d'émargement pour formateur non admin

### DIFF
--- a/autonomie/utils/security.py
+++ b/autonomie/utils/security.py
@@ -175,6 +175,7 @@ DEFAULT_PERM_NEW = [
             'edit_owner.event',
             'list.workshop',
             'view.workshop',
+            'view.timeslot',
         )
     ),
     (
@@ -203,6 +204,7 @@ DEFAULT_PERM_NEW = [
             'edit.workshop',
             'list.workshop',
             'view.workshop',
+            'view.timeslot',
         )
     ),
     (
@@ -509,7 +511,7 @@ def get_timeslot_acl(self):
         acl.append(
             (Allow,
              self.workshop.owner.login.login,
-             "view.workshop"
+             "view.timeslot"
              )
         )
     return acl

--- a/autonomie/utils/security.py
+++ b/autonomie/utils/security.py
@@ -507,14 +507,27 @@ def get_timeslot_acl(self):
     Return ACL for timeslots
     """
     acl = get_event_acl(self)
-    if self.workshop.owner and self.workshop.owner.login:
-        acl.append(
-            (Allow,
-             self.workshop.owner.login.login,
-             "view.timeslot"
-             )
-        )
+    if self.workshop:
+        if self.workshop.owner and self.workshop.owner.login:
+            acl.append(
+                (
+                     Allow,
+                     self.workshop.owner.login.login,
+                     "view.timeslot"
+                 )
+            )
+        for trainer in self.workshop.trainers:
+            if trainer.login:
+                acl.append(
+                    (
+                        Allow,
+                        trainer.login.login,
+                        "view.timeslot",
+                     )
+
+                )
     return acl
+
 
 def get_company_acl(self):
     """

--- a/autonomie/utils/security.py
+++ b/autonomie/utils/security.py
@@ -500,6 +500,19 @@ def get_workshop_acl(self):
 
     return acl
 
+def get_timeslot_acl(self):
+    """
+    Return ACL for timeslots
+    """
+    acl = get_event_acl(self)
+    if self.workshop.owner and self.workshop.owner.login:
+        acl.append(
+            (Allow,
+             self.workshop.owner.login.login,
+             "view.workshop"
+             )
+        )
+    return acl
 
 def get_company_acl(self):
     """
@@ -1441,7 +1454,7 @@ def set_models_acl():
     TaskMention.__acl__ = get_base_acl
     Template.__default_acl__ = get_base_acl
     TemplatingHistory.__default_acl__ = get_base_acl
-    Timeslot.__default_acl__ = get_base_acl
+    Timeslot.__default_acl__ = get_timeslot_acl
     TrainerDatas.__default_acl__ = get_trainerdatas_acl
     TreasuryMeasureGrid.__acl__ = get_accounting_measure_acl
     TreasuryMeasureType.__acl__ = get_base_acl

--- a/autonomie/views/workshops/workshop.py
+++ b/autonomie/views/workshops/workshop.py
@@ -940,7 +940,7 @@ def add_views(config):
     config.add_view(
         timeslot_pdf_view,
         route_name='timeslot.pdf',
-        permission="view.workshop",
+        permission="view.timeslot",
     )
 
     config.add_view(


### PR DESCRIPTION
Le formateur non admin n'avait pas le droit de télécharger la feuille d'émargement.
Il manquait la permission "view.workshop"