### PR TITLE
Reformaultion « Identifiant » → « N° de facture »

### DIFF
--- a/autonomie/panels/task/task_list.py
+++ b/autonomie/panels/task/task_list.py
@@ -122,7 +122,7 @@ class TaskListPanel(object):
         """
         result = []
         result.append(Column("<span class='fa fa-comment'></span>"))
-        result.append(Column(u"Identifiant", u"official_number"))
+        result.append(Column(u"N° facture", u"official_number"))
         if self.is_admin_view:
             result.append(Column(u"Enseigne", u"company"))
         result.append(Column(u"Émise le", 'date'))


### PR DESCRIPTION
Pour coller davantage au jargon.

J'ai cherché les usages de task_list : ça n'est utilisé que pour lister des
factures, jamais des devis (donc ça n'est pas un souci d'utiliser le libellé
« n° de facture »).