### PR TITLE
Fix #993 : Corrige un crash sur l'export NDF les mois accentués

### DIFF
--- a/autonomie/compute/sage.py
+++ b/autonomie/compute/sage.py
@@ -49,10 +49,8 @@ from autonomie.compute.math_utils import (
     reverse_tva,
     compute_tva,
 )
-from autonomie.utils.strings import (
-    format_account,
-    month_name,
-)
+from autonomie.utils.strings import format_account
+from autonomie.utils.datetimes import UnicodeDate
 
 log = logging.getLogger(__name__)
 
@@ -907,7 +905,7 @@ class SageExpenseBase(BaseSageBookEntryFactory):
             beneficiaire=format_account(self.expense.user, reverse=False),
             beneficiaire_LASTNAME=self.expense.user.lastname.upper(),
             expense=self.expense,
-            expense_date=datetime.date(self.expense.year, self.expense.month, 1)
+            expense_date=UnicodeDate(self.expense.year, self.expense.month, 1)
         )
 
 
@@ -1313,7 +1311,7 @@ class SageExpensePaymentMain(BaseSageBookEntryFactory):
             beneficiaire=format_account(self.expense.user, reverse=False),
             beneficiaire_LASTNAME=self.expense.user.lastname.upper(),
             expense=self.expense,
-            expense_date=datetime.date(self.expense.year, self.expense.month, 1)
+            expense_date=UnicodeDate(self.expense.year, self.expense.month, 1)
         )
 
     def set_payment(self, payment):

--- a/autonomie/tests/compute/test_expense.py
+++ b/autonomie/tests/compute/test_expense.py
@@ -116,3 +116,15 @@ def test_real_world_error(mk_expense_type):
     assert last_rounded_total == byline_rounded_total
     # Option 2
     assert last_rounded_total == byproduct_rounded_total
+
+
+def test_expense_label_with_non_ascii_date(pyramid_request):
+    pyramid_request.config = {
+        "bookentry_expense_label_template": u'{expense_date:%B}',
+    }
+    from autonomie.compute.sage import SageExpenseMain
+
+    expense_main = SageExpenseMain(context=None, request=pyramid_request)
+    expense_main.set_expense(MagicMock(year=2018, month=12))
+
+    assert expense_main.libelle == u'décembre'

--- a/autonomie/utils/datetimes.py
+++ b/autonomie/utils/datetimes.py
@@ -1,0 +1,18 @@
+import datetime
+
+
+class UnicodeDate(datetime.date):
+    """Tweaked class formatting as unicode rather than str
+
+    Because original class behaviour (outputing bytes) causes that kind of call
+    to fail if non-ascii char is present in month name ::
+
+        u'{:%B}'.format(date(2018, 12, 12))
+
+    NB: Using Python3 will make this un-necessary (date.__format__ natively
+    outputs unicode).
+
+    """
+    def __format__(self, *args, **kwargs):
+        ret = super(UnicodeDate, self).__format__(*args, **kwargs)
+        return ret.decode('utf-8')


### PR DESCRIPTION
Dans le cas où on utilise le nom du mois dans le libellé d'export comptable

Corrige #993 